### PR TITLE
Custom separator for collection items

### DIFF
--- a/sequence_inserter/consts.py
+++ b/sequence_inserter/consts.py
@@ -10,5 +10,6 @@ License: GNU AGPL, version 3 or later; https://www.gnu.org/licenses/agpl-3.0.en.
 
 # Default settings:
 DEFAULT_DELIMITER = ", "
+DEFAULT_SEPARATOR = ","
 DEFAULT_RANGE = (0, 100)
 DEFAULT_DECIMALS = 2

--- a/sequence_inserter/parser.py
+++ b/sequence_inserter/parser.py
@@ -61,7 +61,8 @@ class Parser(object):
         sample = sample_str.replace(";", ",").split(",")
 
         options = self.getOptions(params[3:])
-        stype, orig_col, ident = self.getSource(ident, sample_str)
+        separator = options.get('sep', unicode(DEFAULT_SEPARATOR))
+        stype, orig_col, ident = self.getSource(ident, sample_str, separator)
 
         rng = None
         try:
@@ -121,7 +122,7 @@ class Parser(object):
             options[key] = val
         return options
 
-    def getSource(self, ident, sample_str):
+    def getSource(self, ident, sample_str, separator):
         """Identify item source"""
         # inline collections:
         col_inline = self.inlinecols.get(ident, None)
@@ -130,7 +131,7 @@ class Parser(object):
         inline = ident.split("|")
         if len(inline) == 2:
             ident = inline[0]
-            col = inline[1].split(",")
+            col = inline[1].split(separator)
             self.inlinecols[ident] = col
             return "inline", col, ident
         # generators:


### PR DESCRIPTION
### Optional item separator field for collection items

adds Additional field option 'sep'

**sep**

Defines a custom item separator between collection items. If not supplied, the add-on will fall back to the default (,).

Example:

`||pick::fruit|apple;orange;banana::3::sep|;||`

Result:

`banana`

**Multiple optional fields**

To specify multiple optional fields, separate them with ::  (do not insert any spaces).

Example:

`||rpick::fruit|apple;orange;banana::3::sep|;::dlm| – ||`

Possible result:

`orange – apple – banana`